### PR TITLE
feat: JS言語切替（JA/EN トグル）を実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,6 +241,7 @@
 <script>
 // ----------------------------------------------------------------
 // 暗号化済みペイロード
+// encrypt-tool.html で生成した文字列をここに貼り付けてください
 // ----------------------------------------------------------------
 const ENCRYPTED_PAYLOAD = "2W6+uUFZAuHaHhmME529TQ==:qRoDKpACkco0jXfT:OPvvJFTjwWMKIvuB9oRVr1XDkos8QzEHj6RlSTjg9/uvG1+bv8m17P4NXXII5LIUtPnGgd9D73g8FADGSBEskCEunec8wQSqxqfRAfDrNkxxkiD4e4DWn/jHNTO0eqB3AM08q2q85SA0eSDRgZsRkOI6Yj8aJnYAvJ092IWCukbAzg7rkcjS7l2eatjHgAmXOkzgsEnJbN5ysoi0DX4S/XKVToz23izDFugl9sz9";
 // ----------------------------------------------------------------

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>履歴書 — 小澤史朗</title>
+  <meta name="description" content="小澤史朗の履歴書">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@300;400;500;700&family=JetBrains+Mono:wght@300;400;500&display=swap" rel="stylesheet">
   <style>
@@ -77,6 +78,9 @@
     .pr-box .tag { display: inline-block; font-family: var(--mono); font-size: 11px; padding: 2px 8px; border: 1px solid var(--border); color: var(--ink-mid); margin-right: 6px; margin-bottom: 4px; border-radius: 2px; }
     .tags { margin-top: 16px; }
     footer { text-align: center; padding: 32px 0; font-family: var(--mono); font-size: 10px; color: var(--ink-lt); border-top: 1px solid var(--border-lt); margin-top: 40px; }
+    .furigana:empty { display: none; }
+    #lang-toggle { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; color: var(--border); background: transparent; border: 1px solid var(--ink-lt); padding: 4px 12px; cursor: pointer; transition: background 0.15s, color 0.15s; }
+    #lang-toggle:hover { background: var(--ink-lt); color: var(--bg); }
     @media print { .page-header { display: none; } .work-scroll-body { max-height: none; overflow: visible; } .scroll-hint, .lock-panel { display: none; } }
     @media (max-width: 600px) { .name-block { grid-template-columns: 1fr; } .photo-placeholder { display: none; } .name-ja { font-size: 32px; } }
   </style>
@@ -84,23 +88,24 @@
 <body>
 
 <header class="page-header">
-  <span class="label">履　歴　書</span>
-  <span class="date">2026年3月1日現在</span>
+  <span class="label" id="header-label">履　歴　書</span>
+  <span class="date" id="header-date">2026年3月1日現在</span>
+  <button id="lang-toggle" onclick="toggleLang()">EN</button>
 </header>
 
 <main class="container">
 
   <div class="name-block">
     <div>
-      <p class="furigana">おざわ　しろう</p>
-      <h1 class="name-ja">小澤　史朗</h1>
-      <p class="birth-info">1972年10月10日生（満53歳）&nbsp;&nbsp;本籍：山梨県</p>
+      <p class="furigana" id="furigana">おざわ　しろう</p>
+      <h1 class="name-ja" id="name-ja">小澤　史朗</h1>
+      <p class="birth-info" id="birth-info">1972年10月10日生（満53歳）&nbsp;&nbsp;本籍：山梨県</p>
     </div>
     <img src="images/striderkein.jpg" alt="小澤史朗" style="width:100px;height:130px;object-fit:cover;border:1px solid var(--border);">
   </div>
 
   <section class="section">
-    <h2 class="section-title">Contact</h2>
+    <h2 class="section-title" id="section-contact">Contact</h2>
     <div class="contact-grid">
       <div class="contact-item">
         <span class="key">GitHub</span>
@@ -115,7 +120,7 @@
             <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
           </svg>
         </div>
-        <p class="lock-label">住所・電話・メールはパスワードで保護されています</p>
+        <p class="lock-label" id="lock-label">住所・電話・メールはパスワードで保護されています</p>
         <div class="pw-form">
           <input type="password" id="pw-input" placeholder="パスワードを入力" autocomplete="off">
           <button id="pw-btn" onclick="unlockContact()">解錠</button>
@@ -124,11 +129,11 @@
       </div>
       <div class="contact-grid" id="unlocked-grid" style="display:none;">
         <div class="contact-item">
-          <span class="key">現住所</span>
+          <span class="key" id="key-address">現住所</span>
           <span class="val" id="out-address"></span>
         </div>
         <div class="contact-item">
-          <span class="key">携帯電話</span>
+          <span class="key" id="key-phone">携帯電話</span>
           <span class="val" id="out-phone"></span>
         </div>
         <div class="contact-item">
@@ -140,10 +145,10 @@
   </section>
 
   <section class="section">
-    <h2 class="section-title">Education — 学歴</h2>
-    <table class="hist-table">
-      <thead><tr><th>年月</th><th>内容</th></tr></thead>
-      <tbody>
+    <h2 class="section-title" id="section-education">Education — 学歴</h2>
+    <table class="hist-table" id="edu-table">
+      <thead><tr><th id="edu-th-ym">年月</th><th id="edu-th-detail">内容</th></tr></thead>
+      <tbody id="edu-tbody">
         <tr><td class="ym">1988.04</td><td>山梨県立甲府東高等学校　入学</td></tr>
         <tr><td class="ym">1991.03</td><td>山梨県立甲府東高等学校　卒業</td></tr>
         <tr><td class="ym">1991.04</td><td>山梨大学　教育学部　教育科学科　入学</td></tr>
@@ -153,10 +158,10 @@
   </section>
 
   <section class="section">
-    <h2 class="section-title">Work History — 職歴</h2>
+    <h2 class="section-title" id="section-work">Work History — 職歴</h2>
     <div class="work-scroll-wrapper">
       <div class="work-scroll-header">
-        <span>年月</span><span>内容</span>
+        <span id="work-th-ym">年月</span><span id="work-th-detail">内容</span>
       </div>
       <div class="work-scroll-body">
         <div class="work-row"><span class="ym">1995.04</span><span class="ev">期間採用教員等として不定期勤務（山梨県）</span></div>
@@ -195,14 +200,14 @@
         <div class="work-row current"><span class="ym">2026.01</span><span class="ev">株式会社シマント　入社（現職）</span></div>
       </div>
     </div>
-    <p class="scroll-hint">↕ スクロールして全職歴を確認できます</p>
+    <p class="scroll-hint" id="scroll-hint">↕ スクロールして全職歴を確認できます</p>
   </section>
 
   <section class="section">
-    <h2 class="section-title">Licenses &amp; Qualifications — 免許・資格</h2>
-    <table class="hist-table">
-      <thead><tr><th>年月</th><th>内容</th></tr></thead>
-      <tbody>
+    <h2 class="section-title" id="section-licenses">Licenses &amp; Qualifications — 免許・資格</h2>
+    <table class="hist-table" id="lic-table">
+      <thead><tr><th id="lic-th-ym">年月</th><th id="lic-th-detail">内容</th></tr></thead>
+      <tbody id="lic-tbody">
         <tr><td class="ym">1992.06</td><td>普通自動車第一種免許　取得</td></tr>
         <tr><td class="ym">1995.03</td><td>小学校教員第一種免許　取得</td></tr>
         <tr><td class="ym">2010.01</td><td>WEBクリエイター上級（株式会社サーティファイ実施）取得</td></tr>
@@ -212,8 +217,8 @@
   </section>
 
   <section class="section">
-    <h2 class="section-title">Self PR — 自己PR</h2>
-    <div class="pr-box">
+    <h2 class="section-title" id="section-pr">Self PR — 自己PR</h2>
+    <div class="pr-box" id="pr-box">
       <p>React / TypeScript を得意とし、フロントエンド開発を中心に実務経験を積んできました。エディタは Vim、キーボードは US 配列派で、コマンドライン環境を好みます。</p>
       <p>AWS においては Amazon Cognito と AWS SAM に詳しく、サーバーレスアーキテクチャの設計・実装が可能です。</p>
       <div class="tags">
@@ -229,17 +234,283 @@
 
 </main>
 
-<footer>
+<footer id="footer">
   履歴書 — 小澤史朗 &nbsp;|&nbsp; 2024年9月10日現在
 </footer>
 
 <script>
 // ----------------------------------------------------------------
 // 暗号化済みペイロード
-// encrypt-tool.html で生成した文字列をここに貼り付けてください
 // ----------------------------------------------------------------
 const ENCRYPTED_PAYLOAD = "2W6+uUFZAuHaHhmME529TQ==:qRoDKpACkco0jXfT:OPvvJFTjwWMKIvuB9oRVr1XDkos8QzEHj6RlSTjg9/uvG1+bv8m17P4NXXII5LIUtPnGgd9D73g8FADGSBEskCEunec8wQSqxqfRAfDrNkxxkiD4e4DWn/jHNTO0eqB3AM08q2q85SA0eSDRgZsRkOI6Yj8aJnYAvJ092IWCukbAzg7rkcjS7l2eatjHgAmXOkzgsEnJbN5ysoi0DX4S/XKVToz23izDFugl9sz9";
 // ----------------------------------------------------------------
+
+let currentLang = 'ja';
+
+const i18n = {
+  ja: {
+    title: '履歴書 — 小澤史朗',
+    description: '小澤史朗の履歴書',
+    headerLabel: '履　歴　書',
+    headerDate: '2026年3月1日現在',
+    furigana: 'おざわ　しろう',
+    name: '小澤　史朗',
+    birthInfo: '1972年10月10日生（満53歳）\u00a0\u00a0本籍：山梨県',
+    photoAlt: '小澤史朗',
+    sectionContact: 'Contact',
+    lockLabel: '住所・電話・メールはパスワードで保護されています',
+    pwPlaceholder: 'パスワードを入力',
+    pwBtn: '解錠',
+    pwError: 'パスワードが正しくありません',
+    keyAddress: '現住所',
+    keyPhone: '携帯電話',
+    keyEmail: 'E-Mail',
+    sectionEducation: 'Education — 学歴',
+    sectionWork: 'Work History — 職歴',
+    sectionLicenses: 'Licenses &amp; Qualifications — 免許・資格',
+    sectionPr: 'Self PR — 自己PR',
+    thYm: '年月',
+    thDetail: '内容',
+    scrollHint: '↕ スクロールして全職歴を確認できます',
+    footer: '履歴書 — 小澤史朗 \u00a0|\u00a0 2024年9月10日現在',
+    education: [
+      { ym: '1988.04', text: '山梨県立甲府東高等学校　入学' },
+      { ym: '1991.03', text: '山梨県立甲府東高等学校　卒業' },
+      { ym: '1991.04', text: '山梨大学　教育学部　教育科学科　入学' },
+      { ym: '1995.03', text: '山梨大学　教育学部　教育科学科　卒業' }
+    ],
+    work: [
+      { ym: '1995.04', text: '期間採用教員等として不定期勤務（山梨県）' },
+      { ym: '1999.03', text: '期間満了により退職' },
+      { ym: '1999.04', text: '県採用教職員として勤務' },
+      { ym: '2000.03', text: '一身上の都合により退職' },
+      { ym: '2002.07', text: '有限会社ナンバーフォー　入社' },
+      { ym: '2003.01', text: '一身上の都合により退職' },
+      { ym: '2003.02', text: '株式会社ヤマト運輸　入社' },
+      { ym: '2005.02', text: '一身上の都合により退職' },
+      { ym: '2005.02', text: '司法書士試験受験のため在宅（〜2007年7月）' },
+      { ym: '2007.11', text: '株式会社アデコ　人材登録（派遣先：NTT東日本）' },
+      { ym: '2009.04', text: '契約期間満了につき退職' },
+      { ym: '2010.04', text: '期間採用教員として山梨県採用' },
+      { ym: '2011.03', text: '任用期間満了につき退職' },
+      { ym: '2011.10', text: '有限会社フロンティア　入社' },
+      { ym: '2012.03', text: '会社都合により解雇' },
+      { ym: '2012.10', text: '有限会社プレザントとの業務請負契約締結' },
+      { ym: '2013.02', text: '業務請負契約終了' },
+      { ym: '2013.03', text: '株式会社デルタウイング　入社' },
+      { ym: '2017.09', text: '一身上の都合により退職' },
+      { ym: '2017.10', text: '光英システム株式会社　入社' },
+      { ym: '2019.02', text: '一身上の都合により退職' },
+      { ym: '2019.03', text: '株式会社ムロドー　入社' },
+      { ym: '2019.12', text: '会社倒産のため退職' },
+      { ym: '2019.12', text: '株式会社システムアイ　入社' },
+      { ym: '2020.12', text: '一身上の都合により退職' },
+      { ym: '2021.02', text: '株式会社グッドワークス　入社' },
+      { ym: '2021.12', text: '一身上の都合により退職' },
+      { ym: '2022.01', text: '2nd community株式会社　入社' },
+      { ym: '2022.07', text: '一身上の都合により退職' },
+      { ym: '2022.08', text: '株式会社ゼヒトモ　入社' },
+      { ym: '2023.08', text: '会社の業績悪化に伴う希望退職' },
+      { ym: '2024.02', text: 'サーバーフリー株式会社　入社' },
+      { ym: '2025.11', text: '一身上の都合により退職' },
+      { ym: '2026.01', text: '株式会社シマント　入社（現職）', current: true }
+    ],
+    licenses: [
+      { ym: '1992.06', text: '普通自動車第一種免許　取得' },
+      { ym: '1995.03', text: '小学校教員第一種免許　取得' },
+      { ym: '2010.01', text: 'WEBクリエイター上級（株式会社サーティファイ実施）取得' },
+      { ym: '2011.10', text: '経済産業省　基本情報技術者試験　合格' }
+    ],
+    prParagraphs: [
+      'React / TypeScript を得意とし、フロントエンド開発を中心に実務経験を積んできました。エディタは Vim、キーボードは US 配列派で、コマンドライン環境を好みます。',
+      'AWS においては Amazon Cognito と AWS SAM に詳しく、サーバーレスアーキテクチャの設計・実装が可能です。'
+    ],
+    prTags: ['React', 'TypeScript', 'Vim', 'AWS SAM', 'Amazon Cognito', 'US配列']
+  },
+  en: {
+    title: 'Resume — Shiro Ozawa',
+    description: 'Resume of Shiro Ozawa',
+    headerLabel: 'Resume',
+    headerDate: 'As of March 1, 2026',
+    furigana: '',
+    name: 'Shiro Ozawa',
+    birthInfo: 'Born October 10, 1972 (Age 53)\u00a0\u00a0Domicile: Yamanashi, Japan',
+    photoAlt: 'Shiro Ozawa',
+    sectionContact: 'Contact',
+    lockLabel: 'Address, phone, and email are password-protected',
+    pwPlaceholder: 'Enter password',
+    pwBtn: 'Unlock',
+    pwError: 'Incorrect password',
+    keyAddress: 'Address',
+    keyPhone: 'Phone',
+    keyEmail: 'E-Mail',
+    sectionEducation: 'Education',
+    sectionWork: 'Work History',
+    sectionLicenses: 'Licenses &amp; Qualifications',
+    sectionPr: 'Self PR',
+    thYm: 'Date',
+    thDetail: 'Details',
+    scrollHint: '↕ Scroll to view full work history',
+    footer: 'Resume — Shiro Ozawa \u00a0|\u00a0 As of September 10, 2024',
+    education: [
+      { ym: '1988.04', text: 'Enrolled in Yamanashi Prefectural Kofu-Higashi High School' },
+      { ym: '1991.03', text: 'Graduated from Yamanashi Prefectural Kofu-Higashi High School' },
+      { ym: '1991.04', text: 'Enrolled in University of Yamanashi, Faculty of Education, Dept. of Educational Science' },
+      { ym: '1995.03', text: 'Graduated from University of Yamanashi, Faculty of Education, Dept. of Educational Science' }
+    ],
+    work: [
+      { ym: '1995.04', text: 'Worked as a fixed-term teacher (Yamanashi Prefecture)' },
+      { ym: '1999.03', text: 'Left upon contract expiration' },
+      { ym: '1999.04', text: 'Employed as a prefectural teacher' },
+      { ym: '2000.03', text: 'Resigned for personal reasons' },
+      { ym: '2002.07', text: 'Joined Number Four Co., Ltd.' },
+      { ym: '2003.01', text: 'Resigned for personal reasons' },
+      { ym: '2003.02', text: 'Joined Yamato Transport Co., Ltd.' },
+      { ym: '2005.02', text: 'Resigned for personal reasons' },
+      { ym: '2005.02', text: 'Studied for judicial scrivener exam (until Jul 2007)' },
+      { ym: '2007.11', text: 'Registered with Adecco Ltd. (Dispatched to NTT East)' },
+      { ym: '2009.04', text: 'Left upon contract expiration' },
+      { ym: '2010.04', text: 'Hired as a fixed-term teacher by Yamanashi Prefecture' },
+      { ym: '2011.03', text: 'Left upon term expiration' },
+      { ym: '2011.10', text: 'Joined Frontier Co., Ltd.' },
+      { ym: '2012.03', text: 'Terminated due to company circumstances' },
+      { ym: '2012.10', text: 'Contracted with Pleasant Co., Ltd.' },
+      { ym: '2013.02', text: 'Contract ended' },
+      { ym: '2013.03', text: 'Joined Delta Wing Co., Ltd.' },
+      { ym: '2017.09', text: 'Resigned for personal reasons' },
+      { ym: '2017.10', text: 'Joined Koei System Co., Ltd.' },
+      { ym: '2019.02', text: 'Resigned for personal reasons' },
+      { ym: '2019.03', text: 'Joined Murodo Co., Ltd.' },
+      { ym: '2019.12', text: 'Left due to company bankruptcy' },
+      { ym: '2019.12', text: 'Joined System-i Co., Ltd.' },
+      { ym: '2020.12', text: 'Resigned for personal reasons' },
+      { ym: '2021.02', text: 'Joined Goodworks Co., Ltd.' },
+      { ym: '2021.12', text: 'Resigned for personal reasons' },
+      { ym: '2022.01', text: 'Joined 2nd Community Co., Ltd.' },
+      { ym: '2022.07', text: 'Resigned for personal reasons' },
+      { ym: '2022.08', text: 'Joined Zehitomo, Inc.' },
+      { ym: '2023.08', text: 'Voluntary retirement due to company downturn' },
+      { ym: '2024.02', text: 'Joined Serverfree Co., Ltd.' },
+      { ym: '2025.11', text: 'Resigned for personal reasons' },
+      { ym: '2026.01', text: 'Joined Shimanto Co., Ltd. (Current)', current: true }
+    ],
+    licenses: [
+      { ym: '1992.06', text: 'Ordinary Motor Vehicle License (Class 1)' },
+      { ym: '1995.03', text: 'Elementary School Teacher License (Class 1)' },
+      { ym: '2010.01', text: 'Web Creator Advanced Certificate (Certify Inc.)' },
+      { ym: '2011.10', text: 'METI Fundamental Information Technology Engineer Examination — Passed' }
+    ],
+    prParagraphs: [
+      'Specializing in React / TypeScript with extensive hands-on experience in frontend development. I prefer Vim as my editor, US keyboard layout, and a command-line-driven workflow.',
+      'On AWS, I have deep expertise in Amazon Cognito and AWS SAM, capable of designing and implementing serverless architectures.'
+    ],
+    prTags: ['React', 'TypeScript', 'Vim', 'AWS SAM', 'Amazon Cognito', 'US Layout']
+  }
+};
+
+function applyLang(lang) {
+  currentLang = lang;
+  const t = i18n[lang];
+
+  // html lang, title, meta
+  document.documentElement.lang = lang;
+  document.title = t.title;
+  document.querySelector('meta[name="description"]').content = t.description;
+
+  // header
+  document.getElementById('header-label').textContent = t.headerLabel;
+  document.getElementById('header-date').textContent = t.headerDate;
+
+  // name block
+  document.getElementById('furigana').textContent = t.furigana;
+  document.getElementById('name-ja').textContent = t.name;
+  document.getElementById('birth-info').innerHTML = t.birthInfo;
+  document.querySelector('.name-block img').alt = t.photoAlt;
+
+  // contact section
+  document.getElementById('section-contact').textContent = t.sectionContact;
+  document.getElementById('lock-label').textContent = t.lockLabel;
+  document.getElementById('pw-input').placeholder = t.pwPlaceholder;
+  document.getElementById('pw-error').textContent = t.pwError;
+  // only update button text if not in loading state
+  const pwBtn = document.getElementById('pw-btn');
+  if (!pwBtn.disabled) pwBtn.textContent = t.pwBtn;
+  document.getElementById('key-address').textContent = t.keyAddress;
+  document.getElementById('key-phone').textContent = t.keyPhone;
+
+  // education table
+  document.getElementById('section-education').textContent = t.sectionEducation;
+  document.getElementById('edu-th-ym').textContent = t.thYm;
+  document.getElementById('edu-th-detail').textContent = t.thDetail;
+  const eduTbody = document.getElementById('edu-tbody');
+  eduTbody.innerHTML = '';
+  t.education.forEach(row => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = '<td class="ym">' + row.ym + '</td><td>' + row.text + '</td>';
+    eduTbody.appendChild(tr);
+  });
+
+  // work history
+  document.getElementById('section-work').textContent = t.sectionWork;
+  document.getElementById('work-th-ym').textContent = t.thYm;
+  document.getElementById('work-th-detail').textContent = t.thDetail;
+  const workBody = document.querySelector('.work-scroll-body');
+  const scrollTop = workBody.scrollTop;
+  workBody.innerHTML = '';
+  t.work.forEach(row => {
+    const div = document.createElement('div');
+    div.className = 'work-row' + (row.current ? ' current' : '');
+    div.innerHTML = '<span class="ym">' + row.ym + '</span><span class="ev">' + row.text + '</span>';
+    workBody.appendChild(div);
+  });
+  workBody.scrollTop = scrollTop;
+  document.getElementById('scroll-hint').textContent = t.scrollHint;
+
+  // licenses
+  document.getElementById('section-licenses').innerHTML = t.sectionLicenses;
+  document.getElementById('lic-th-ym').textContent = t.thYm;
+  document.getElementById('lic-th-detail').textContent = t.thDetail;
+  const licTbody = document.getElementById('lic-tbody');
+  licTbody.innerHTML = '';
+  t.licenses.forEach(row => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = '<td class="ym">' + row.ym + '</td><td>' + row.text + '</td>';
+    licTbody.appendChild(tr);
+  });
+
+  // self PR
+  document.getElementById('section-pr').textContent = t.sectionPr;
+  const prBox = document.getElementById('pr-box');
+  prBox.innerHTML = '';
+  t.prParagraphs.forEach(p => {
+    const el = document.createElement('p');
+    el.textContent = p;
+    prBox.appendChild(el);
+  });
+  const tagsDiv = document.createElement('div');
+  tagsDiv.className = 'tags';
+  t.prTags.forEach(tag => {
+    const span = document.createElement('span');
+    span.className = 'tag';
+    span.textContent = tag;
+    tagsDiv.appendChild(span);
+  });
+  prBox.appendChild(tagsDiv);
+
+  // footer
+  document.getElementById('footer').innerHTML = t.footer;
+
+  // toggle button
+  document.getElementById('lang-toggle').textContent = lang === 'ja' ? 'EN' : 'JA';
+
+  // persist
+  localStorage.setItem('cv-lang', lang);
+  history.replaceState(null, '', lang === 'en' ? '#en' : window.location.pathname);
+}
+
+function toggleLang() {
+  applyLang(currentLang === 'ja' ? 'en' : 'ja');
+}
 
 async function unlockContact() {
   const password = document.getElementById('pw-input').value;
@@ -285,8 +556,10 @@ async function unlockContact() {
     document.getElementById('unlocked-grid').style.display = '';
 
   } catch (_) {
+    const t = i18n[currentLang];
+    errEl.textContent = t.pwError;
     errEl.style.display = 'block';
-    btn.textContent = '解錠';
+    btn.textContent = t.pwBtn;
     btn.disabled = false;
   }
 }
@@ -294,6 +567,16 @@ async function unlockContact() {
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('pw-input')
     .addEventListener('keydown', e => { if (e.key === 'Enter') unlockContact(); });
+
+  // determine initial language: URL hash > localStorage > default (ja)
+  let lang = 'ja';
+  if (window.location.hash === '#en') {
+    lang = 'en';
+  } else {
+    const stored = localStorage.getItem('cv-lang');
+    if (stored === 'en') lang = 'en';
+  }
+  if (lang !== 'ja') applyLang(lang);
 });
 </script>
 

--- a/index.html
+++ b/index.html
@@ -247,6 +247,58 @@ const ENCRYPTED_PAYLOAD = "2W6+uUFZAuHaHhmME529TQ==:qRoDKpACkco0jXfT:OPvvJFTjwWM
 
 let currentLang = 'ja';
 
+// 共通データ（言語非依存）
+const tableData = {
+  education: [
+    { ym: '1988.04' },
+    { ym: '1991.03' },
+    { ym: '1991.04' },
+    { ym: '1995.03' }
+  ],
+  work: [
+    { ym: '1995.04' },
+    { ym: '1999.03' },
+    { ym: '1999.04' },
+    { ym: '2000.03' },
+    { ym: '2002.07' },
+    { ym: '2003.01' },
+    { ym: '2003.02' },
+    { ym: '2005.02' },
+    { ym: '2005.02' },
+    { ym: '2007.11' },
+    { ym: '2009.04' },
+    { ym: '2010.04' },
+    { ym: '2011.03' },
+    { ym: '2011.10' },
+    { ym: '2012.03' },
+    { ym: '2012.10' },
+    { ym: '2013.02' },
+    { ym: '2013.03' },
+    { ym: '2017.09' },
+    { ym: '2017.10' },
+    { ym: '2019.02' },
+    { ym: '2019.03' },
+    { ym: '2019.12' },
+    { ym: '2019.12' },
+    { ym: '2020.12' },
+    { ym: '2021.02' },
+    { ym: '2021.12' },
+    { ym: '2022.01' },
+    { ym: '2022.07' },
+    { ym: '2022.08' },
+    { ym: '2023.08' },
+    { ym: '2024.02' },
+    { ym: '2025.11' },
+    { ym: '2026.01', current: true }
+  ],
+  licenses: [
+    { ym: '1992.06' },
+    { ym: '1995.03' },
+    { ym: '2010.01' },
+    { ym: '2011.10' }
+  ]
+};
+
 const i18n = {
   ja: {
     title: '履歴書 — 小澤史朗',
@@ -274,52 +326,52 @@ const i18n = {
     scrollHint: '↕ スクロールして全職歴を確認できます',
     footer: '履歴書 — 小澤史朗 \u00a0|\u00a0 2024年9月10日現在',
     education: [
-      { ym: '1988.04', text: '山梨県立甲府東高等学校　入学' },
-      { ym: '1991.03', text: '山梨県立甲府東高等学校　卒業' },
-      { ym: '1991.04', text: '山梨大学　教育学部　教育科学科　入学' },
-      { ym: '1995.03', text: '山梨大学　教育学部　教育科学科　卒業' }
+      '山梨県立甲府東高等学校　入学',
+      '山梨県立甲府東高等学校　卒業',
+      '山梨大学　教育学部　教育科学科　入学',
+      '山梨大学　教育学部　教育科学科　卒業'
     ],
     work: [
-      { ym: '1995.04', text: '期間採用教員等として不定期勤務（山梨県）' },
-      { ym: '1999.03', text: '期間満了により退職' },
-      { ym: '1999.04', text: '県採用教職員として勤務' },
-      { ym: '2000.03', text: '一身上の都合により退職' },
-      { ym: '2002.07', text: '有限会社ナンバーフォー　入社' },
-      { ym: '2003.01', text: '一身上の都合により退職' },
-      { ym: '2003.02', text: '株式会社ヤマト運輸　入社' },
-      { ym: '2005.02', text: '一身上の都合により退職' },
-      { ym: '2005.02', text: '司法書士試験受験のため在宅（〜2007年7月）' },
-      { ym: '2007.11', text: '株式会社アデコ　人材登録（派遣先：NTT東日本）' },
-      { ym: '2009.04', text: '契約期間満了につき退職' },
-      { ym: '2010.04', text: '期間採用教員として山梨県採用' },
-      { ym: '2011.03', text: '任用期間満了につき退職' },
-      { ym: '2011.10', text: '有限会社フロンティア　入社' },
-      { ym: '2012.03', text: '会社都合により解雇' },
-      { ym: '2012.10', text: '有限会社プレザントとの業務請負契約締結' },
-      { ym: '2013.02', text: '業務請負契約終了' },
-      { ym: '2013.03', text: '株式会社デルタウイング　入社' },
-      { ym: '2017.09', text: '一身上の都合により退職' },
-      { ym: '2017.10', text: '光英システム株式会社　入社' },
-      { ym: '2019.02', text: '一身上の都合により退職' },
-      { ym: '2019.03', text: '株式会社ムロドー　入社' },
-      { ym: '2019.12', text: '会社倒産のため退職' },
-      { ym: '2019.12', text: '株式会社システムアイ　入社' },
-      { ym: '2020.12', text: '一身上の都合により退職' },
-      { ym: '2021.02', text: '株式会社グッドワークス　入社' },
-      { ym: '2021.12', text: '一身上の都合により退職' },
-      { ym: '2022.01', text: '2nd community株式会社　入社' },
-      { ym: '2022.07', text: '一身上の都合により退職' },
-      { ym: '2022.08', text: '株式会社ゼヒトモ　入社' },
-      { ym: '2023.08', text: '会社の業績悪化に伴う希望退職' },
-      { ym: '2024.02', text: 'サーバーフリー株式会社　入社' },
-      { ym: '2025.11', text: '一身上の都合により退職' },
-      { ym: '2026.01', text: '株式会社シマント　入社（現職）', current: true }
+      '期間採用教員等として不定期勤務（山梨県）',
+      '期間満了により退職',
+      '県採用教職員として勤務',
+      '一身上の都合により退職',
+      '有限会社ナンバーフォー　入社',
+      '一身上の都合により退職',
+      '株式会社ヤマト運輸　入社',
+      '一身上の都合により退職',
+      '司法書士試験受験のため在宅（〜2007年7月）',
+      '株式会社アデコ　人材登録（派遣先：NTT東日本）',
+      '契約期間満了につき退職',
+      '期間採用教員として山梨県採用',
+      '任用期間満了につき退職',
+      '有限会社フロンティア　入社',
+      '会社都合により解雇',
+      '有限会社プレザントとの業務請負契約締結',
+      '業務請負契約終了',
+      '株式会社デルタウイング　入社',
+      '一身上の都合により退職',
+      '光英システム株式会社　入社',
+      '一身上の都合により退職',
+      '株式会社ムロドー　入社',
+      '会社倒産のため退職',
+      '株式会社システムアイ　入社',
+      '一身上の都合により退職',
+      '株式会社グッドワークス　入社',
+      '一身上の都合により退職',
+      '2nd community株式会社　入社',
+      '一身上の都合により退職',
+      '株式会社ゼヒトモ　入社',
+      '会社の業績悪化に伴う希望退職',
+      'サーバーフリー株式会社　入社',
+      '一身上の都合により退職',
+      '株式会社シマント　入社（現職）'
     ],
     licenses: [
-      { ym: '1992.06', text: '普通自動車第一種免許　取得' },
-      { ym: '1995.03', text: '小学校教員第一種免許　取得' },
-      { ym: '2010.01', text: 'WEBクリエイター上級（株式会社サーティファイ実施）取得' },
-      { ym: '2011.10', text: '経済産業省　基本情報技術者試験　合格' }
+      '普通自動車第一種免許　取得',
+      '小学校教員第一種免許　取得',
+      'WEBクリエイター上級（株式会社サーティファイ実施）取得',
+      '経済産業省　基本情報技術者試験　合格'
     ],
     prParagraphs: [
       'React / TypeScript を得意とし、フロントエンド開発を中心に実務経験を積んできました。エディタは Vim、キーボードは US 配列派で、コマンドライン環境を好みます。',
@@ -353,52 +405,52 @@ const i18n = {
     scrollHint: '↕ Scroll to view full work history',
     footer: 'Resume — Shiro Ozawa \u00a0|\u00a0 As of September 10, 2024',
     education: [
-      { ym: '1988.04', text: 'Enrolled in Yamanashi Prefectural Kofu-Higashi High School' },
-      { ym: '1991.03', text: 'Graduated from Yamanashi Prefectural Kofu-Higashi High School' },
-      { ym: '1991.04', text: 'Enrolled in University of Yamanashi, Faculty of Education, Dept. of Educational Science' },
-      { ym: '1995.03', text: 'Graduated from University of Yamanashi, Faculty of Education, Dept. of Educational Science' }
+      'Enrolled in Yamanashi Prefectural Kofu-Higashi High School',
+      'Graduated from Yamanashi Prefectural Kofu-Higashi High School',
+      'Enrolled in University of Yamanashi, Faculty of Education, Dept. of Educational Science',
+      'Graduated from University of Yamanashi, Faculty of Education, Dept. of Educational Science'
     ],
     work: [
-      { ym: '1995.04', text: 'Worked as a fixed-term teacher (Yamanashi Prefecture)' },
-      { ym: '1999.03', text: 'Left upon contract expiration' },
-      { ym: '1999.04', text: 'Employed as a prefectural teacher' },
-      { ym: '2000.03', text: 'Resigned for personal reasons' },
-      { ym: '2002.07', text: 'Joined Number Four Co., Ltd.' },
-      { ym: '2003.01', text: 'Resigned for personal reasons' },
-      { ym: '2003.02', text: 'Joined Yamato Transport Co., Ltd.' },
-      { ym: '2005.02', text: 'Resigned for personal reasons' },
-      { ym: '2005.02', text: 'Studied for judicial scrivener exam (until Jul 2007)' },
-      { ym: '2007.11', text: 'Registered with Adecco Ltd. (Dispatched to NTT East)' },
-      { ym: '2009.04', text: 'Left upon contract expiration' },
-      { ym: '2010.04', text: 'Hired as a fixed-term teacher by Yamanashi Prefecture' },
-      { ym: '2011.03', text: 'Left upon term expiration' },
-      { ym: '2011.10', text: 'Joined Frontier Co., Ltd.' },
-      { ym: '2012.03', text: 'Terminated due to company circumstances' },
-      { ym: '2012.10', text: 'Contracted with Pleasant Co., Ltd.' },
-      { ym: '2013.02', text: 'Contract ended' },
-      { ym: '2013.03', text: 'Joined Delta Wing Co., Ltd.' },
-      { ym: '2017.09', text: 'Resigned for personal reasons' },
-      { ym: '2017.10', text: 'Joined Koei System Co., Ltd.' },
-      { ym: '2019.02', text: 'Resigned for personal reasons' },
-      { ym: '2019.03', text: 'Joined Murodo Co., Ltd.' },
-      { ym: '2019.12', text: 'Left due to company bankruptcy' },
-      { ym: '2019.12', text: 'Joined System-i Co., Ltd.' },
-      { ym: '2020.12', text: 'Resigned for personal reasons' },
-      { ym: '2021.02', text: 'Joined Goodworks Co., Ltd.' },
-      { ym: '2021.12', text: 'Resigned for personal reasons' },
-      { ym: '2022.01', text: 'Joined 2nd Community Co., Ltd.' },
-      { ym: '2022.07', text: 'Resigned for personal reasons' },
-      { ym: '2022.08', text: 'Joined Zehitomo, Inc.' },
-      { ym: '2023.08', text: 'Voluntary retirement due to company downturn' },
-      { ym: '2024.02', text: 'Joined Serverfree Co., Ltd.' },
-      { ym: '2025.11', text: 'Resigned for personal reasons' },
-      { ym: '2026.01', text: 'Joined Shimanto Co., Ltd. (Current)', current: true }
+      'Worked as a fixed-term teacher (Yamanashi Prefecture)',
+      'Left upon contract expiration',
+      'Employed as a prefectural teacher',
+      'Resigned for personal reasons',
+      'Joined Number Four Co., Ltd.',
+      'Resigned for personal reasons',
+      'Joined Yamato Transport Co., Ltd.',
+      'Resigned for personal reasons',
+      'Studied for judicial scrivener exam (until Jul 2007)',
+      'Registered with Adecco Ltd. (Dispatched to NTT East)',
+      'Left upon contract expiration',
+      'Hired as a fixed-term teacher by Yamanashi Prefecture',
+      'Left upon term expiration',
+      'Joined Frontier Co., Ltd.',
+      'Terminated due to company circumstances',
+      'Contracted with Pleasant Co., Ltd.',
+      'Contract ended',
+      'Joined Delta Wing Co., Ltd.',
+      'Resigned for personal reasons',
+      'Joined Koei System Co., Ltd.',
+      'Resigned for personal reasons',
+      'Joined Murodo Co., Ltd.',
+      'Left due to company bankruptcy',
+      'Joined System-i Co., Ltd.',
+      'Resigned for personal reasons',
+      'Joined Goodworks Co., Ltd.',
+      'Resigned for personal reasons',
+      'Joined 2nd Community Co., Ltd.',
+      'Resigned for personal reasons',
+      'Joined Zehitomo, Inc.',
+      'Voluntary retirement due to company downturn',
+      'Joined Serverfree Co., Ltd.',
+      'Resigned for personal reasons',
+      'Joined Shimanto Co., Ltd. (Current)'
     ],
     licenses: [
-      { ym: '1992.06', text: 'Ordinary Motor Vehicle License (Class 1)' },
-      { ym: '1995.03', text: 'Elementary School Teacher License (Class 1)' },
-      { ym: '2010.01', text: 'Web Creator Advanced Certificate (Certify Inc.)' },
-      { ym: '2011.10', text: 'METI Fundamental Information Technology Engineer Examination — Passed' }
+      'Ordinary Motor Vehicle License (Class 1)',
+      'Elementary School Teacher License (Class 1)',
+      'Web Creator Advanced Certificate (Certify Inc.)',
+      'METI Fundamental Information Technology Engineer Examination — Passed'
     ],
     prParagraphs: [
       'Specializing in React / TypeScript with extensive hands-on experience in frontend development. I prefer Vim as my editor, US keyboard layout, and a command-line-driven workflow.',
@@ -444,9 +496,9 @@ function applyLang(lang) {
   document.getElementById('edu-th-detail').textContent = t.thDetail;
   const eduTbody = document.getElementById('edu-tbody');
   eduTbody.innerHTML = '';
-  t.education.forEach(row => {
+  tableData.education.forEach((row, i) => {
     const tr = document.createElement('tr');
-    tr.innerHTML = '<td class="ym">' + row.ym + '</td><td>' + row.text + '</td>';
+    tr.innerHTML = '<td class="ym">' + row.ym + '</td><td>' + t.education[i] + '</td>';
     eduTbody.appendChild(tr);
   });
 
@@ -457,10 +509,10 @@ function applyLang(lang) {
   const workBody = document.querySelector('.work-scroll-body');
   const scrollTop = workBody.scrollTop;
   workBody.innerHTML = '';
-  t.work.forEach(row => {
+  tableData.work.forEach((row, i) => {
     const div = document.createElement('div');
     div.className = 'work-row' + (row.current ? ' current' : '');
-    div.innerHTML = '<span class="ym">' + row.ym + '</span><span class="ev">' + row.text + '</span>';
+    div.innerHTML = '<span class="ym">' + row.ym + '</span><span class="ev">' + t.work[i] + '</span>';
     workBody.appendChild(div);
   });
   workBody.scrollTop = scrollTop;
@@ -472,9 +524,9 @@ function applyLang(lang) {
   document.getElementById('lic-th-detail').textContent = t.thDetail;
   const licTbody = document.getElementById('lic-tbody');
   licTbody.innerHTML = '';
-  t.licenses.forEach(row => {
+  tableData.licenses.forEach((row, i) => {
     const tr = document.createElement('tr');
-    tr.innerHTML = '<td class="ym">' + row.ym + '</td><td>' + row.text + '</td>';
+    tr.innerHTML = '<td class="ym">' + row.ym + '</td><td>' + t.licenses[i] + '</td>';
     licTbody.appendChild(tr);
   });
 


### PR DESCRIPTION
## Summary
- `index.html` に `i18n` JSオブジェクト（辞書）による JA/EN 言語切替を実装
- ヘッダーにトグルボタンを追加し、全セクション（名前・学歴・職歴・資格・自己PR・フッター）のテキストを動的に切替
- `localStorage` / URLハッシュ(`#en`) による言語設定の永続化

## Test plan
- [ ] トグルボタンで JA/EN を切替え、全セクションのテキストが正しく切り替わること
- [ ] `#en` ハッシュ付きでページをリロードし、英語で表示されること
- [ ] パスワード復号後に言語切替しても、ラベルのみ変わり値が保持されること
- [ ] リロード後に `localStorage` から言語設定が復元されること
- [ ] モバイル表示（600px以下）でレイアウトが崩れないこと
- [ ] 印刷プレビューでトグルボタンが非表示であること

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)